### PR TITLE
Added an automatic checker on startup & on demand.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 tkinterdnd2
 xmltodict
 pyinstaller
+
+# For Update check on startup
+requests

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -1,0 +1,5 @@
+
+
+
+GITHUB_REPO = "AeroFlorian/netconf-parser"
+GITHUB_REPO_URL = f"https://github.com/{GITHUB_REPO}"

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -1,5 +1,5 @@
 
 
 
-GITHUB_REPO = "Krisscut/netconf-parser"
+GITHUB_REPO = "AeroFlorian/netconf-parser"
 GITHUB_REPO_URL = f"https://github.com/{GITHUB_REPO}"

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -1,5 +1,5 @@
 
 
 
-GITHUB_REPO = "AeroFlorian/netconf-parser"
+GITHUB_REPO = "Krisscut/netconf-parser"
 GITHUB_REPO_URL = f"https://github.com/{GITHUB_REPO}"

--- a/src/Display.py
+++ b/src/Display.py
@@ -17,6 +17,8 @@ import lzma
 import webbrowser
 from version import __version__
 import Utils
+import Constants
+import UpdateChecker
 
 APP_NAME = f"NetConfParser - {__version__}{ ' - DEV' if Utils.is_dev_mode() else ''}"
 ENORMOUS_RPC=20000
@@ -398,6 +400,8 @@ class NetConfParserWindow(TkinterDnD.Tk):
 
         self.enable_drop_for_result_box() # Only the visible box should have the drag & drop
 
+        threading.Thread(target=UpdateChecker.check_for_updates, daemon=True).start()
+
     def open_dialog_and_load_file(self, event):
         f = filedialog.askopenfile()
         if f:
@@ -545,7 +549,7 @@ class NetConfParserWindow(TkinterDnD.Tk):
         description_label.pack(pady=10)
 
         def open_github():
-            webbrowser.open("https://github.com/AeroFlorian/netconf-parser")
+            webbrowser.open(Constants.GITHUB_REPO_URL)
 
         github_link = tk.Label(popup, text="GitHub Repository", fg="blue", cursor="hand2")
         github_link.pack(pady=10)

--- a/src/Display.py
+++ b/src/Display.py
@@ -308,6 +308,7 @@ class NetConfParserWindow(TkinterDnD.Tk):
 
         help_menu = tk.Menu(self.menu_bar, tearoff=0)
         help_menu.add_command(label="About", command=self.show_about_popup)
+        help_menu.add_command(label="Check for Update", command=self.check_for_update)
         self.menu_bar.add_cascade(label="?", menu=help_menu)
 
         frame_l = tk.Frame(width=200, height=400)
@@ -399,7 +400,9 @@ class NetConfParserWindow(TkinterDnD.Tk):
         self.copy_to_clip = copy_to_clip
 
         self.enable_drop_for_result_box() # Only the visible box should have the drag & drop
+        self.check_for_update()
 
+    def check_for_update(self):
         threading.Thread(target=UpdateChecker.check_for_updates, daemon=True).start()
 
     def open_dialog_and_load_file(self, event):

--- a/src/UpdateChecker.py
+++ b/src/UpdateChecker.py
@@ -1,0 +1,35 @@
+import requests
+import Constants
+from tkinter import messagebox
+import logging
+import version
+from packaging import version
+import webbrowser
+
+LOGGER = logging.getLogger(__name__)
+
+def check_for_updates():
+    try:
+        response = requests.get(f"https://api.github.com/repos/{Constants.GITHUB_REPO}/releases/latest")
+        response.raise_for_status()
+        latest_release = response.json()
+        latest_version = latest_release["tag_name"]  # e.g., "v1.8.0"
+        download_url = latest_release["html_url"]
+
+        current_version_parsed = version.parse(version.__version__)
+        new_version_parsed = version.parse(latest_version.lstrip("v"))         #strip "v" from the tag for comparison
+
+        INFO.debug(f"Current version: {current_version_parsed}, Latest version: {new_version_parsed}")
+
+
+        if current_version_parsed < new_version_parsed:
+            if messagebox.askyesno(
+                "Update Available",
+                f"A new version ({latest_version}) is available (Current version is {VERSION}). Would you like to download it?"
+            ):
+                webbrowser.open(download_url)
+
+        #TODO: Could potentially stored last version checked somewhere so that we don't ask every time if user reply no. Would need a new menu item for that to force update tho.
+
+    except Exception as e:
+        LOGGER.error(f"Failed to check for updates: {e}")

--- a/src/UpdateChecker.py
+++ b/src/UpdateChecker.py
@@ -3,6 +3,7 @@ import Constants
 from tkinter import messagebox
 import logging
 import version
+from version import __version__
 from packaging import version
 import webbrowser
 
@@ -16,16 +17,15 @@ def check_for_updates():
         latest_version = latest_release["tag_name"]  # e.g., "v1.8.0"
         download_url = latest_release["html_url"]
 
-        current_version_parsed = version.parse(version.__version__)
+        current_version_parsed = version.parse(__version__)
         new_version_parsed = version.parse(latest_version.lstrip("v"))         #strip "v" from the tag for comparison
 
-        INFO.debug(f"Current version: {current_version_parsed}, Latest version: {new_version_parsed}")
-
+        LOGGER.info(f"Current version: {current_version_parsed}, Latest version: {new_version_parsed}")
 
         if current_version_parsed < new_version_parsed:
             if messagebox.askyesno(
                 "Update Available",
-                f"A new version ({latest_version}) is available (Current version is {VERSION}). Would you like to download it?"
+                f"A new version ({latest_version}) is available (Current version is {__version__}). Would you like to download it?"
             ):
                 webbrowser.open(download_url)
 


### PR DESCRIPTION
On startup, check against the github repo if there is an update.
Is there is one and user reply yes, open the github release page.

Potential improvements in the future:

- Add a 3rd reply: do not ask again so that we don't check it on next startup for this version.
- Automatic updated: if user reply yes, automatically download and run it.

**Based on https://github.com/AeroFlorian/netconf-parser/pull/28, so maybe merge the other pull request first and let me know so that I can update this one**

