### PR TITLE
fix: Fixed "NetconfProxy" format parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyinstaller
 requests
 pylint
 pytest
+lxml

--- a/src/LineRemover.py
+++ b/src/LineRemover.py
@@ -45,7 +45,11 @@ class LineRemover:
                                  r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z Dbg: .*? Session \d+: (?:Sending|Received) message:",
                                  ""),
             LineRemoverRegexRule("Sending",
-                                 r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{7} INF (?:Sending|Received) message: ", "")]
+                                 r"\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}.\d{3,}.*(?:Sending|Received)( message)?: ", ""),
+            LineRemoverRegexRule("Received",
+                                 r"\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}.\d{3,}.*(?:Sending|Received)( message)?: ", "")
+        ]
+
 
     def remove_unwanted_parts(self, full_lines: str):
         for rule in self.rules:

--- a/src/Logger.py
+++ b/src/Logger.py
@@ -46,4 +46,4 @@ class Logger:
         return self.logger
 
 
-logger = Logger('Logger', None, True).getLogger()
+logger = Logger('netconf-logger', None, True).getLogger()


### PR DESCRIPTION
It seems NetconfProxy file format got broken recently, at least the <rpc> seems to not be parsed properly, but from my test it also seems that it skipped some session detection as well.

### Format handled now:
```xml
2025-08-12 11:35:59.528 [Netconf_session_id=<id>][Redis_client_id=<id>][Username=<username>] Received: <rpc message-id="fc237084-b6ab-40d7-ba6f-43d613c316a3" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
<rpc-content/>
</rpc>
```

Main difference is the **T** not being present between date & time, as well as number of digit in milliseconds, + the extra stuff between date/time & payload.
Also it seems in my format the xmlns= is AFTER the id and it was causing issues.

### Example before/after here:
<img width="1920" height="1160" alt="image" src="https://github.com/user-attachments/assets/3d0a3590-2107-44e7-acc9-a25902bb0bf8" />
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/c3198af3-e717-4514-8318-ab07a248ab15" />

### Details:
- Replaces regex-based NETCONF message extraction with XML parsing using lxml for improved robustness. 
- Removes the RegexToNetconfMessage class and updates NetConfParser to use Message.from_xml. 
- Refines regex rules in LineRemover for better log filtering. 
- Updates logger name and adds lxml to requirements.

### Note:

We should look into adding some pytest with the various format to avoid breaking things in the future.

